### PR TITLE
Add Clawdan AI agent card

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 import { Hero } from '../components/hero';
 import { BookCall } from '../components/book-call';
+import { AIAgent } from '../components/ai-agent';
 import Experience from '../components/experience';
 import { Footer } from '../components/footer';
 import { experience } from '../config/experience';
@@ -9,6 +10,7 @@ export default function Page() {
     <div className="max-w-2xl mx-auto px-6 pb-20">
       <Hero />
       <BookCall />
+      <AIAgent />
       <Experience experiences={experience} />
       <Footer />
     </div>

--- a/src/components/ai-agent.tsx
+++ b/src/components/ai-agent.tsx
@@ -1,0 +1,33 @@
+import { Bot } from 'lucide-react';
+
+export function AIAgent() {
+  return (
+    <section className="mb-6">
+      <a
+        href="https://moltbook.com/u/Clawdan"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="block p-3 rounded-lg border border-neutral-800 bg-neutral-900/50 hover:bg-neutral-900 hover:border-neutral-700 transition-all group"
+      >
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <div className="p-2 rounded-md bg-neutral-800 text-neutral-400 group-hover:text-orange-400 group-hover:bg-neutral-800/80 transition-colors">
+              <Bot className="w-5 h-5" />
+            </div>
+            <div>
+              <h3 className="text-neutral-200 font-medium group-hover:text-white transition-colors">
+                Meet Clawdan
+              </h3>
+              <p className="text-sm text-neutral-500 group-hover:text-neutral-400 transition-colors">
+                My personal AI agent on OpenClaw
+              </p>
+            </div>
+          </div>
+          <div className="text-neutral-600 group-hover:text-orange-400 transition-colors">
+            →
+          </div>
+        </div>
+      </a>
+    </section>
+  );
+}


### PR DESCRIPTION
Adds a card linking to my Moltbook profile, matching the style of the Book a Call card.

**Changes:**
- New `AIAgent` component (`src/components/ai-agent.tsx`)
- Added to homepage after Book a Call

**Design:**
- Same card style as BookCall
- Bot icon (lucide-react)
- Orange accent color on hover (to differentiate from purple)
- Links to https://moltbook.com/u/Clawdan

*Created by Clawdan 🐾*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adds a new external link card to the homepage; no data handling or auth logic is touched.
> 
> **Overview**
> Adds a new `AIAgent` card component (using `lucide-react`’s `Bot` icon) that links out to `https://moltbook.com/u/Clawdan` with hover styling.
> 
> Updates `src/app/page.tsx` to render `AIAgent` on the homepage directly after `BookCall`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b1aa48277f1aef563815d5eeca958b100f6492cf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added an AI Agent card to the homepage to introduce Clawdan and link to the Moltbook profile. This gives visitors a quick way to try the agent.

- **New Features**
  - New AIAgent component with bot icon and orange hover accent (src/components/ai-agent.tsx).
  - Inserted after Book a Call on the homepage (src/app/page.tsx).
  - Opens https://moltbook.com/u/Clawdan in a new tab.

<sup>Written for commit b1aa48277f1aef563815d5eeca958b100f6492cf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

